### PR TITLE
Start trial for both subset and anonymize

### DIFF
--- a/Run-Autopilot.ps1
+++ b/Run-Autopilot.ps1
@@ -356,7 +356,7 @@ if (-not $skipAuth) {
         Write-Host ""
         Write-Host "INFO:  Authorizing rganonymize, and starting a trial (if not already started):" -ForegroundColor DarkCyan
         Write-Host "CMD:    rganonymize auth login --i-agree-to-the-eula" -ForegroundColor Blue
-        & rganonymize auth login --i-agree-to-the-eula
+        & rganonymize auth login --i-agree-to-the-eula  --start-trial
     }
 }
 


### PR DESCRIPTION
Fixes bug where TDM starts subsetter trial, but not anonymize, and then anonymize starts failing.